### PR TITLE
compileOnly("javax.servlet:javax.servlet-api:3.1.0")

### DIFF
--- a/karibu-dsl-v10/build.gradle.kts
+++ b/karibu-dsl-v10/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
 
     // Vaadin
     compile("com.vaadin:vaadin-core:${ext["vaadin10_version"]}")
-    compile("javax.servlet:javax.servlet-api:3.1.0")
+    compileOnly("javax.servlet:javax.servlet-api:3.1.0")
 
     // IDEA language injections
     compile("com.intellij:annotations:12.0")


### PR DESCRIPTION
is changed to
compileOnly("javax.servlet:javax.servlet-api:3.1.0") in order to avoid conflicts with newer versions of e.g. 4.x of javax.servlet-api.

Apache Tomcat 9.x from Spring Boot 2.1.x requires javax.servlet-api 4.x, but spring boot fat jar (due to 'compile') contains javax.servlet-api:3.1.0.
It raises errors like "java.lang.NoSuchMethodError: javax.servlet.http.HttpServletRequest.getHttpServletMapping()Ljavax/servlet/http/HttpServletMapping;"