### PR TITLE
Adding support to replace drawer and content within AppLayout.

### DIFF
--- a/example/src/main/kotlin/com/vaadin/starter/beveragebuddy/ui/categories/CategoriesList.kt
+++ b/example/src/main/kotlin/com/vaadin/starter/beveragebuddy/ui/categories/CategoriesList.kt
@@ -18,6 +18,7 @@ package com.vaadin.starter.beveragebuddy.ui.categories
 import com.github.mvysny.karibudsl.v10.*
 import com.github.mvysny.kaributools.ModifierKey.Alt
 import com.github.mvysny.kaributools.addShortcut
+import com.vaadin.flow.component.HasComponents
 import com.vaadin.flow.component.Key.KEY_E
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.button.ButtonVariant
@@ -134,13 +135,13 @@ class CategoriesList : KComposite() {
         updateView()
     }
 
-    private fun createEditButton(category: Category): Button =
-        Button("Edit").apply {
-            icon = Icon(VaadinIcon.EDIT)
-            addClassName("category__edit")
-            addThemeVariants(ButtonVariant.LUMO_TERTIARY)
-            onClick { edit(category) }
-        }
+    private fun HasComponents.createEditButton(category: Category): Button =
+            button("Edit") {
+                icon = Icon(VaadinIcon.EDIT)
+                addClassName("category__edit")
+                addThemeVariants(ButtonVariant.LUMO_TERTIARY)
+                onClick { edit(category) }
+            }
 
     private fun edit(category: Category) {
         editorDialog.edit(category)

--- a/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/AppLayout.kt
+++ b/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/AppLayout.kt
@@ -4,6 +4,7 @@ import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.HasComponents
 import com.vaadin.flow.component.applayout.AppLayout
 import com.vaadin.flow.component.applayout.DrawerToggle
+import com.vaadin.flow.component.shared.SlotUtils
 import com.vaadin.flow.dom.Element
 
 /**
@@ -54,10 +55,33 @@ public fun (@VaadinDsl AppLayout).navbar(touchOptimized: Boolean = false, block:
 }
 
 /**
+ * [AppLayout.java](https://github.com/vaadin/vaadin-app-layout-flow/blob/master/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java)
+ * ```
+ * public void addToDrawer(Component... components) {
+ *         SlotUtils.addToSlot(this, "drawer", components);
+ *     }
+ * ```
+ * [removeDrawer] is a temporary solution, until a similar method is added to [AppLayout] class.
+ */
+@VaadinDsl
+public fun (@VaadinDsl AppLayout).removeDrawer() {
+    SlotUtils.clearSlot(this, "drawer")
+}
+
+/**
  * Populates the AppLayout drawer slot. `sideNav{}` is the best way to populate the drawer with Vaadin 24.
  */
 @VaadinDsl
 public fun (@VaadinDsl AppLayout).drawer(block: (@VaadinDsl HasComponents).() -> Unit = {}) {
+
+    /**
+     * It allows to replace a drawer, i.e. to have several drawers.
+     * For example, navbar contains several tabs.
+     *      When a tab is selected, it set its specific drawer and re-populates AppLayout content.
+     *      If a tab doesn't have a drawer, removeDrawer() can be called to by its own to clear the previous assigned drawer.
+     */
+    removeDrawer()
+
     val dummy = object : HasComponents {
         override fun getElement(): Element = throw UnsupportedOperationException("Not expected to be called")
         override fun add(vararg components: Component) {
@@ -80,7 +104,6 @@ public fun (@VaadinDsl AppLayout).content(block: (@VaadinDsl HasComponents).() -
         override fun add(vararg components: Component) {
             require(components.size < 2) { "Too many components to add - AppLayout content can only host one! ${components.toList()}" }
             val component = components.firstOrNull() ?: return
-            check(this@content.content == null) { "The content has already been initialized!" }
             this@content.setContent(component)
         }
     }

--- a/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/AppLayout.kt
+++ b/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/AppLayout.kt
@@ -5,7 +5,6 @@ import com.vaadin.flow.component.HasComponents
 import com.vaadin.flow.component.applayout.AppLayout
 import com.vaadin.flow.component.applayout.DrawerToggle
 import com.vaadin.flow.component.shared.SlotUtils
-import com.vaadin.flow.dom.Element
 
 /**
  * Creates an [App Layout](https://vaadin.com/components/vaadin-app-layout). Example:
@@ -45,13 +44,11 @@ public fun (@VaadinDsl HasComponents).appLayout(block: (@VaadinDsl AppLayout).()
  */
 @VaadinDsl
 public fun (@VaadinDsl AppLayout).navbar(touchOptimized: Boolean = false, block: (@VaadinDsl HasComponents).() -> Unit = {}) {
-    val dummy = object : HasComponents {
-        override fun getElement(): Element = throw UnsupportedOperationException("Not expected to be called")
+    object : DummyHasComponents {
         override fun add(vararg components: Component) {
             addToNavbar(touchOptimized, *components)
         }
-    }
-    dummy.block()
+    }.block()
 }
 
 /**
@@ -82,13 +79,11 @@ public fun (@VaadinDsl AppLayout).drawer(block: (@VaadinDsl HasComponents).() ->
      */
     removeDrawer()
 
-    val dummy = object : HasComponents {
-        override fun getElement(): Element = throw UnsupportedOperationException("Not expected to be called")
+    object : DummyHasComponents {
         override fun add(vararg components: Component) {
             addToDrawer(*components)
         }
-    }
-    dummy.block()
+    }.block()
 }
 
 /**
@@ -99,15 +94,12 @@ public fun (@VaadinDsl AppLayout).drawer(block: (@VaadinDsl HasComponents).() ->
  */
 @VaadinDsl
 public fun (@VaadinDsl AppLayout).content(block: (@VaadinDsl HasComponents).() -> Unit = {}) {
-    val dummy = object : HasComponents {
-        override fun getElement(): Element = throw UnsupportedOperationException("Not expected to be called")
+    object : DummyHasComponents {
         override fun add(vararg components: Component) {
             require(components.size < 2) { "Too many components to add - AppLayout content can only host one! ${components.toList()}" }
-            val component = components.firstOrNull() ?: return
-            this@content.setContent(component)
+            this@content.content = components.firstOrNull()
         }
-    }
-    dummy.block()
+    }.block()
 }
 
 /**

--- a/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/AppLayout.kt
+++ b/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/AppLayout.kt
@@ -32,6 +32,16 @@ public fun (@VaadinDsl HasComponents).appLayout(block: (@VaadinDsl AppLayout).()
         = init(AppLayout(), block)
 
 /**
+ * [removeNavbar] removes all components from the navbar slot.
+ * Also see [AppLayout.addToNavbar]
+ */
+@VaadinDsl
+public fun (@VaadinDsl AppLayout).removeNavbar(touchOptimized: Boolean) {
+    val slot = "navbar" + (if (touchOptimized) " touch-optimized" else "")
+    SlotUtils.clearSlot(this, slot)
+}
+
+/**
  * Allows you to populate the [AppLayout.addToNavbar] in a DSL fashion:
  * ```
  * appLayout {
@@ -52,13 +62,8 @@ public fun (@VaadinDsl AppLayout).navbar(touchOptimized: Boolean = false, block:
 }
 
 /**
- * [AppLayout.java](https://github.com/vaadin/vaadin-app-layout-flow/blob/master/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java)
- * ```
- * public void addToDrawer(Component... components) {
- *         SlotUtils.addToSlot(this, "drawer", components);
- *     }
- * ```
- * [removeDrawer] is a temporary solution, until a similar method is added to [AppLayout] class.
+ * [removeDrawer] removes all components from the drawer slot.
+ * Also see [AppLayout.addToDrawer]
  */
 @VaadinDsl
 public fun (@VaadinDsl AppLayout).removeDrawer() {
@@ -70,20 +75,20 @@ public fun (@VaadinDsl AppLayout).removeDrawer() {
  */
 @VaadinDsl
 public fun (@VaadinDsl AppLayout).drawer(block: (@VaadinDsl HasComponents).() -> Unit = {}) {
-
-    /**
-     * It allows to replace a drawer, i.e. to have several drawers.
-     * For example, navbar contains several tabs.
-     *      When a tab is selected, it set its specific drawer and re-populates AppLayout content.
-     *      If a tab doesn't have a drawer, removeDrawer() can be called to by its own to clear the previous assigned drawer.
-     */
-    removeDrawer()
-
     object : DummyHasComponents {
         override fun add(vararg components: Component) {
             addToDrawer(*components)
         }
     }.block()
+}
+
+/**
+ * [removeContent] removes all components from the content.
+ * Also see [AppLayout.setContent]
+ */
+@VaadinDsl
+public fun (@VaadinDsl AppLayout).removeContent() {
+    content = null
 }
 
 /**
@@ -97,7 +102,9 @@ public fun (@VaadinDsl AppLayout).content(block: (@VaadinDsl HasComponents).() -
     object : DummyHasComponents {
         override fun add(vararg components: Component) {
             require(components.size < 2) { "Too many components to add - AppLayout content can only host one! ${components.toList()}" }
-            this@content.content = components.firstOrNull()
+            val component = components.firstOrNull() ?: return
+            check(this@content.content == null) { "The content has already been initialized!" }
+            this@content.content = component
         }
     }.block()
 }

--- a/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/Grid.kt
+++ b/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/Grid.kt
@@ -249,11 +249,15 @@ public fun <T> (@VaadinDsl Grid<T>).column(
  * @return the new column
  */
 @VaadinDsl
-public fun <T, V : Component?> (@VaadinDsl Grid<T>).componentColumn(
-    componentProvider: ValueProvider<T, V>,
+public fun <T, V : Component> (@VaadinDsl Grid<T>).componentColumn(
+    componentProvider: HasComponents.(T) -> V,
     block: (@VaadinDsl Grid.Column<T>).() -> Unit = {}
 ): Grid.Column<T> {
-    val column = addComponentColumn(componentProvider)
+    val column = addComponentColumn {
+        provideSingleComponent {
+            componentProvider(it)
+        }
+    }
     column.block()
     return column
 }

--- a/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/Upload.kt
+++ b/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/Upload.kt
@@ -1,5 +1,6 @@
 package com.github.mvysny.karibudsl.v10
 
+import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.HasComponents
 import com.vaadin.flow.component.upload.Receiver
 import com.vaadin.flow.component.upload.Upload
@@ -96,3 +97,12 @@ public fun (@VaadinDsl UploadI18N.Uploading).error(block: (@VaadinDsl UploadI18N
     error.block()
     return error
 }
+
+@VaadinDsl
+public fun <TComponent : Component> (@VaadinDsl Upload).button(block: (@VaadinDsl HasComponents).() -> TComponent) {
+    element.removeAllChildren()
+    uploadButton = provideSingleComponent {
+        block()
+    }
+}
+

--- a/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/VaadinComponents.kt
+++ b/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/VaadinComponents.kt
@@ -17,7 +17,6 @@ import com.vaadin.flow.component.progressbar.ProgressBar
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup
 import com.vaadin.flow.component.select.Select
 import com.vaadin.flow.component.timepicker.TimePicker
-import com.vaadin.flow.dom.Element
 import com.vaadin.flow.shared.Registration
 
 /**
@@ -159,20 +158,13 @@ public fun (@VaadinDsl HasComponents).scroller(
     init(Scroller(scrollDirection), block)
 
 @VaadinDsl
-public fun <T> (@VaadinDsl Scroller).content(block: (@VaadinDsl HasComponents).() -> T): T {
+public fun <TComponent : Component> (@VaadinDsl Scroller).content(block: (@VaadinDsl HasComponents).() -> TComponent): TComponent {
     element.removeAllChildren()
-    val dummy = object : HasComponents {
-        override fun getElement(): Element = throw UnsupportedOperationException("Not expected to be called")
-        override fun add(vararg components: Component) {
-            require(components.size < 2) { "Too many components to add - scroller can only host one! ${components.toList()}" }
-            val component: Component = components.firstOrNull() ?: return
-            check(this@content.element.childCount == 0) { "The scroller can only host one component at most" }
-            content = component
-        }
+    return provideSingleComponent {
+        block()
+    }.also {
+        content = it
     }
-    val result: T = dummy.block()
-    checkNotNull(content) { "`block` must add exactly one component to the scroller" }
-    return result
 }
 
 /**

--- a/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/VaadinDsl.kt
+++ b/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/VaadinDsl.kt
@@ -2,6 +2,7 @@ package com.github.mvysny.karibudsl.v10
 
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.HasComponents
+import com.vaadin.flow.dom.Element
 
 // annotating DSL functions with @VaadinDsl will make Intellij mark the DSL functions in a special way
 // which makes them stand out apart from the common functions, which is very nice.
@@ -55,3 +56,28 @@ public fun <T : Component> (@VaadinDsl HasComponents).init(
     component.block()
     return component
 }
+
+/**
+ * Adapter, which provides dummy [HasComponents] receiver
+ * for some karibu-dsl methods accepting parameter block: (@VaadinDsl HasComponents).() -> Unit
+ * TODO Migrate object : HasComponents {} to object : DummyHasComponents {}
+ */
+public interface DummyHasComponents : HasComponents {
+    override fun getElement(): Element =
+        throw UnsupportedOperationException("Not expected to be called")
+}
+
+/**
+ * Adapter from a Vaadin method expecting single Component to karibu-dsl.
+ * TODO Migrate object : HasComponents {} providing single Component to provideSingleComponent {}
+ */
+@VaadinDsl
+public fun provideSingleComponent(block: (@VaadinDsl HasComponents).() -> Component): Component {
+    return object : DummyHasComponents {
+        override fun add(vararg components: Component) {
+            require(components.size == 1) { "provideSingleComponent supports one component only" }
+            // Do nothing
+        }
+    }.block()
+}
+

--- a/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/VaadinDsl.kt
+++ b/karibu-dsl/src/main/kotlin/com/github/mvysny/karibudsl/v10/VaadinDsl.kt
@@ -2,6 +2,7 @@ package com.github.mvysny.karibudsl.v10
 
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.HasComponents
+import com.vaadin.flow.component.upload.Upload
 import com.vaadin.flow.dom.Element
 
 // annotating DSL functions with @VaadinDsl will make Intellij mark the DSL functions in a special way
@@ -69,10 +70,27 @@ public interface DummyHasComponents : HasComponents {
 
 /**
  * Adapter from a Vaadin method expecting single Component to karibu-dsl.
- * TODO Migrate object : HasComponents {} providing single Component to provideSingleComponent {}
+ * See [componentColumn], (@VaadinDsl Scroller).content, [Upload.button]
+ *
+ * Examples of usage:
+ * ```kotlin
+ *
+ * componentColumn { row ->
+ *    button(row.name) {...}
+ * }
+ *
+ * val span: Span = scroller.content { span("Foo") }
+ *
+ * upload {
+ *   button {
+ *     iconButton(VaadinIcon.UPLOAD.create())
+ *   }
+ * }
+ *
+ * ```
  */
 @VaadinDsl
-public fun provideSingleComponent(block: (@VaadinDsl HasComponents).() -> Component): Component {
+public fun <TComponent : Component> provideSingleComponent(block: (@VaadinDsl HasComponents).() -> TComponent): TComponent {
     return object : DummyHasComponents {
         override fun add(vararg components: Component) {
             require(components.size == 1) { "provideSingleComponent supports one component only" }


### PR DESCRIPTION
Purpose: To have several drawers and contents for AppLayout and switch between them.

For example, navbar contains several tabs.
When a tab is selected, it set its specific drawer and re-populates AppLayout content.
If a tab doesn't have a drawer, removeDrawer() can be called to by its own to clear the previous assigned drawer.

From  AppLayout.content the restriction has been removed.
`check(this@content.content == null) { "The content has already been initialized!" }`
